### PR TITLE
tickets/DM-34349 Make scons tests depend on building pipelines

### DIFF
--- a/pipelines/SConscript
+++ b/pipelines/SConscript
@@ -85,3 +85,5 @@ targets.setdefault("pipelines", []).extend(
 )
 
 env.AlwaysBuild(targets["pipelines"])
+env.Requires(targets['pipelines'], targets["version"])
+env.Requires(targets['tests'], targets["pipelines"])


### PR DESCRIPTION
Ensure that the pipelines have all been built prior to running any
tests.