### PR TITLE
DM-38953: Don't set allConnections in __init__.

### DIFF
--- a/python/lsst/analysis/drp/gatherResourceUsage.py
+++ b/python/lsst/analysis/drp/gatherResourceUsage.py
@@ -97,7 +97,6 @@ class GatherResourceUsageConnections(
             self.input_metadata,
             dimensions=list(self.config.dimensions),
         )
-        self.allConnections["input_metadata"] = self.input_metadata
 
 
 class GatherResourceUsageConfig(


### PR DESCRIPTION
This is now unnecessary and prohibited by the PipelineTaskConnections base class.