### PR TITLE
Revert "DM-38953: Don't set allConnections in __init__."

### DIFF
--- a/python/lsst/analysis/drp/gatherResourceUsage.py
+++ b/python/lsst/analysis/drp/gatherResourceUsage.py
@@ -97,6 +97,7 @@ class GatherResourceUsageConnections(
             self.input_metadata,
             dimensions=list(self.config.dimensions),
         )
+        self.allConnections["input_metadata"] = self.input_metadata
 
 
 class GatherResourceUsageConfig(


### PR DESCRIPTION
Reverts lsst/analysis_drp#61

See breakage discussion in https://lsstc.slack.com/archives/C2JPMCF5X/p1683754340587629