### PR TITLE
DM-38952: Switch ConfigurableAction imports to pex_config.

### DIFF
--- a/python/lsst/analysis/drp/calcFunctors.py
+++ b/python/lsst/analysis/drp/calcFunctors.py
@@ -30,7 +30,7 @@ import treecorr
 from astropy import units as u
 
 from lsst.pex.config import ChoiceField, ConfigField, DictField, Field, FieldValidationError
-from lsst.pipe.tasks.configurableActions import ConfigurableActionField
+from lsst.pex.config.configurableActions import ConfigurableActionField
 from lsst.pipe.tasks.dataFrameActions import (CoordColumn, DataFrameAction, DivideColumns,
                                               FractionalDifferenceColumns, MultiColumnAction,
                                               SingleColumnAction, DiffOfDividedColumns,

--- a/python/lsst/analysis/drp/catalogMatch.py
+++ b/python/lsst/analysis/drp/catalogMatch.py
@@ -8,7 +8,7 @@ import lsst.pipe.base as pipeBase
 import lsst.pex.config as pexConfig
 import lsst.geom
 from lsst.meas.algorithms import ReferenceObjectLoader, LoadReferenceObjectsTask
-from lsst.pipe.tasks.configurableActions import ConfigurableActionStructField
+from lsst.pex.config.configurableActions import ConfigurableActionStructField
 from lsst.skymap import BaseSkyMap
 
 from . import dataSelectors

--- a/python/lsst/analysis/drp/colorColorFitPlot.py
+++ b/python/lsst/analysis/drp/colorColorFitPlot.py
@@ -9,7 +9,7 @@ import matplotlib.patheffects as pathEffects
 
 import lsst.pipe.base as pipeBase
 import lsst.pex.config as pexConfig
-from lsst.pipe.tasks.configurableActions import ConfigurableActionStructField
+from lsst.pex.config.configurableActions import ConfigurableActionStructField
 from lsst.pipe.tasks.dataFrameActions import MagColumnNanoJansky
 
 from .calcFunctors import ExtinctionCorrectedMagDiff

--- a/python/lsst/analysis/drp/colorColorPlot.py
+++ b/python/lsst/analysis/drp/colorColorPlot.py
@@ -7,7 +7,7 @@ import scipy.stats as scipyStats
 
 import lsst.pipe.base as pipeBase
 import lsst.pex.config as pexConfig
-from lsst.pipe.tasks.configurableActions import ConfigurableActionStructField
+from lsst.pex.config.configurableActions import ConfigurableActionStructField
 from lsst.pipe.tasks.dataFrameActions import MagColumnNanoJansky
 from .calcFunctors import ExtinctionCorrectedMagDiff
 from .dataSelectors import FlagSelector, SnSelector, StarIdentifier, GalaxyIdentifier, CoaddPlotFlagSelector

--- a/python/lsst/analysis/drp/histPlot.py
+++ b/python/lsst/analysis/drp/histPlot.py
@@ -8,7 +8,7 @@ from matplotlib.patches import Rectangle
 from matplotlib.collections import PatchCollection
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
-from lsst.pipe.tasks.configurableActions import ConfigurableActionStructField
+from lsst.pex.config.configurableActions import ConfigurableActionStructField
 from lsst.skymap import BaseSkyMap
 import lsst.pipe.base as pipeBase
 import lsst.pex.config as pexConfig

--- a/python/lsst/analysis/drp/redGalaxyTruthAssociation.py
+++ b/python/lsst/analysis/drp/redGalaxyTruthAssociation.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 import lsst.pipe.base as pipeBase
 import lsst.pex.config as pexConfig
-from lsst.pipe.tasks.configurableActions import ConfigurableActionStructField
+from lsst.pex.config.configurableActions import ConfigurableActionStructField
 
 from . import dataSelectors as dataSelectors
 

--- a/python/lsst/analysis/drp/rhoPlot.py
+++ b/python/lsst/analysis/drp/rhoPlot.py
@@ -24,7 +24,7 @@ import numpy as np
 
 import lsst.pipe.base as pipeBase
 from lsst.pex.config import ChoiceField, DictField, Field
-from lsst.pipe.tasks.configurableActions import ConfigurableActionField, ConfigurableActionStructField
+from lsst.pex.config.configurableActions import ConfigurableActionField, ConfigurableActionStructField
 
 from . import dataSelectors
 from .calcFunctors import CalcRhoStatistics

--- a/python/lsst/analysis/drp/scatterPlot.py
+++ b/python/lsst/analysis/drp/scatterPlot.py
@@ -28,7 +28,7 @@ from matplotlib.path import Path
 from matplotlib.collections import PatchCollection
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
-from lsst.pipe.tasks.configurableActions import ConfigurableActionStructField
+from lsst.pex.config.configurableActions import ConfigurableActionStructField
 from lsst.pipe.tasks.dataFrameActions import MagColumnNanoJansky, SingleColumnAction
 from lsst.skymap import BaseSkyMap
 

--- a/python/lsst/analysis/drp/skyPlot.py
+++ b/python/lsst/analysis/drp/skyPlot.py
@@ -7,7 +7,7 @@ from matplotlib.patches import Rectangle
 import matplotlib.patheffects as pathEffects
 import lsst.pipe.base as pipeBase
 import lsst.pex.config as pexConfig
-from lsst.pipe.tasks.configurableActions import ConfigurableActionStructField
+from lsst.pex.config.configurableActions import ConfigurableActionStructField
 from lsst.pipe.tasks.dataFrameActions import CoordColumn, SingleColumnAction
 from lsst.skymap import BaseSkyMap
 


### PR DESCRIPTION
@timj , I forgot to include this PR in the rest of the DM-38952 request because I'd forgotten about the branch: it's just updating the import path for some types to correspond to a deprecate-and-move that happened earlier.  It's here just because I got frustrated with all of the warnings while running building QuantumGraphs.

Could you take a quick look?