### PR TITLE
DM-41043: Drop references to lsst.daf.butler.core.

### DIFF
--- a/python/lsst/analysis/drp/gatherResourceUsage.py
+++ b/python/lsst/analysis/drp/gatherResourceUsage.py
@@ -36,7 +36,7 @@ import numpy as np
 import pandas as pd
 
 from lsst.daf.butler import Butler, DataCoordinate, DatasetRef, DatasetType, DimensionGraph, Quantum
-from lsst.daf.butler.core.utils import globToRegex
+from lsst.daf.butler.utils import globToRegex
 from lsst.pex.config import Field, ListField
 from lsst.pipe.base import (
     Instrument,
@@ -779,7 +779,7 @@ def _dtype_from_field_spec(field_spec):
 
     Parameters
     ----------
-    field_spec : `lsst.daf.butler.core.ddl.FieldSpec`
+    field_spec : `lsst.daf.butler.ddl.FieldSpec`
         Object describing the field in a SQL-friendly sense.
 
     Returns

--- a/python/lsst/analysis/drp/histPlot.py
+++ b/python/lsst/analysis/drp/histPlot.py
@@ -167,8 +167,7 @@ class HistPlotTask(pipeBase.PipelineTask):
         ----------
         catPlot : `pandas.core.frame.DataFrame`
             The catalog to plot the points from.
-        dataId :
-        `lsst.daf.butler.core.dimensions._coordinate._ExpandedTupleDataCoordinate`
+        dataId : `lsst.daf.butler.DataCoordinate`
             The dimensions that the plot is being made from.
         runName : `str`
             The name of the collection that the plot is written out to.

--- a/python/lsst/analysis/drp/plotUtils.py
+++ b/python/lsst/analysis/drp/plotUtils.py
@@ -36,8 +36,7 @@ def parsePlotInfo(dataId, runName, tableName, bands, plotName, SN, SNFlux):
 
     Parameters
     ----------
-    dataId : `lsst.daf.butler.core.dimensions.`
-             `_coordinate._ExpandedTupleDataCoordinate`
+    dataId : `lsst.daf.butler.DataCoordinate`
     runName : `str`
 
     Returns

--- a/python/lsst/analysis/drp/rhoPlot.py
+++ b/python/lsst/analysis/drp/rhoPlot.py
@@ -241,7 +241,7 @@ class RhoPlotTask(pipeBase.PipelineTask):
         ----------
         catPlot : `~pandas.core.frame.DataFrame`
             The catalog to compute the rho-statistics from.
-        dataId: `~lsst.daf.butler.core.dimensions._coordinate._ExpandedTupleDataCoordinate`  # noqa
+        dataId : `~lsst.daf.butler.DataCoordinate`
             The dimensions that the plot is being made from.
         runName : `str`
             The name of the collection that the plot is written out to.

--- a/python/lsst/analysis/drp/scatterPlot.py
+++ b/python/lsst/analysis/drp/scatterPlot.py
@@ -225,8 +225,7 @@ class ScatterPlotWithTwoHistsTask(pipeBase.PipelineTask):
         ----------
         catPlot : `pandas.core.frame.DataFrame`
             The catalog to plot the points from.
-        dataId :
-        `lsst.daf.butler.core.dimensions._coordinate._ExpandedTupleDataCoordinate`
+        dataId : `lsst.daf.butler.DataCoordinate`
             The dimensions that the plot is being made from.
         runName : `str`
             The name of the collection that the plot is written out to.

--- a/python/lsst/analysis/drp/scatterPlotVisit.py
+++ b/python/lsst/analysis/drp/scatterPlotVisit.py
@@ -92,8 +92,7 @@ class ScatterPlotVisitTask(ScatterPlotWithTwoHistsTask):
         ----------
         catPlot : `pandas.core.frame.DataFrame`
             The catalog to plot the points from.
-        dataId :
-        `lsst.daf.butler.core.dimensions._coordinate._ExpandedTupleDataCoordinate`
+        dataId : `lsst.daf.butler.DataCoordinate`
             The dimensions that the plot is being made from.
         runName : `str`
             The name of the collection that the plot is written out to.

--- a/python/lsst/analysis/drp/skyPlot.py
+++ b/python/lsst/analysis/drp/skyPlot.py
@@ -141,8 +141,7 @@ class SkyPlotTask(pipeBase.PipelineTask):
         ----------
         catPlot : `pandas.core.frame.DataFrame`
             The catalog to plot the points from.
-        dataId :
-        `lsst.daf.butler.core.dimensions._coordinate._ExpandedTupleDataCoordinate`
+        dataId : `lsst.daf.butler.DataCoordinate`
             The dimensions that the plot is being made from.
         runName : `str`
             The name of the collection that the plot is written out to.

--- a/python/lsst/analysis/drp/skyPlotVisit.py
+++ b/python/lsst/analysis/drp/skyPlotVisit.py
@@ -96,8 +96,7 @@ class SkyPlotVisitTask(SkyPlotTask):
         ----------
         catPlot : `pandas.core.frame.DataFrame`
             The catalog to plot the points from.
-        dataId :
-        `lsst.daf.butler.core.dimensions._coordinate._ExpandedTupleDataCoordinate`
+        dataId : `lsst.daf.butler.DataCoordinate`
             The dimensions that the plot is being made from.
         runName : `str`
             The name of the collection that the plot is written out to.


### PR DESCRIPTION
This was not a public namespace, and now it doesn't exist.